### PR TITLE
Fix redirection issues on Firefox and Safari

### DIFF
--- a/src/client/java/com/tiji/media/WebGuideServer.java
+++ b/src/client/java/com/tiji/media/WebGuideServer.java
@@ -30,8 +30,7 @@ public class WebGuideServer {
 
     public static void start() throws IOException {
         server.createContext("/callback", new callbackHandler());
-        server.createContext("/secret", new secretHandler());
-        server.createContext("/id", new idHandler());
+        server.createContext("/config", new configHandler());
         server.createContext("/", new rootHandler());
 
         server.setExecutor(null);
@@ -103,28 +102,31 @@ public class WebGuideServer {
             WebGuideServer.stop();
         }
     }
-    private static class secretHandler implements HttpHandler {
+    private static class configHandler implements HttpHandler {
         @Override
         public void handle(HttpExchange exchange) throws IOException {
-            String Code = exchange.getRequestURI().getQuery().split("=")[1];
-            MediaClient.CONFIG.clientSecret(Code);
+            String[] Queries = exchange.getRequestURI().getQuery().split("&");
+            String Id = "";
+            String Secret = "";
 
-            Media.LOGGER.info("Client Secret Received");
-
-            String response = "Received";
-            exchange.sendResponseHeaders(200, response.length());
-            OutputStream os = exchange.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
-        }
-    }
-    private static class idHandler implements HttpHandler {
-        @Override
-        public void handle(HttpExchange exchange) throws IOException {
-            String Code = exchange.getRequestURI().getQuery().split("=")[1];
-            MediaClient.CONFIG.clientId(Code);
+            for(String pair : Queries) {
+                String[] kv = pair.split("=");
+                if(kv.length != 2) continue;
+                if(kv[0].equalsIgnoreCase("id")) Id = kv[1];
+                else if(kv[0].equalsIgnoreCase("secret")) Secret = kv[1];
+            }
+            if(Id.length()==0 || Secret.length()==0) {
+                String response = "Bad Request";
+                exchange.sendResponseHeaders(400, response.length());
+                OutputStream os = exchange.getResponseBody();
+                os.write(response.getBytes());
+                os.close();
+                return;
+            }
 
             Media.LOGGER.info("Client ID Received");
+            MediaClient.CONFIG.clientId(Id);
+            MediaClient.CONFIG.clientSecret(Secret);
 
             String response = "Received";
             exchange.sendResponseHeaders(200, response.length());

--- a/src/client/java/com/tiji/media/WebGuideServer.java
+++ b/src/client/java/com/tiji/media/WebGuideServer.java
@@ -3,19 +3,10 @@ package com.tiji.media;
 import com.sun.net.httpserver.*;
 import net.minecraft.client.MinecraftClient;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.concurrent.Executor;
 
 public class WebGuideServer {
     public static HttpServer server;

--- a/src/client/resources/guide/en_us.html
+++ b/src/client/resources/guide/en_us.html
@@ -46,16 +46,12 @@
     </style>
     <script>
         function redirect() {
-            var xmlHttp1 = new XMLHttpRequest();
-            xmlHttp1.open("GET", "http://127.0.0.1:25566/secret?code=" + document.getElementById('clientsecret').value, true);
-            xmlHttp1.send(null);
-
-            var xmlHttp2 = new XMLHttpRequest();
-            xmlHttp2.open("GET", "http://127.0.0.1:25566/id?code=" + document.getElementById('clientid').value, true);
-            xmlHttp2.send(null);
-
-            url = "https://accounts.spotify.com/authorize?response_type=code&client_id=" + document.getElementById('clientid').value + "&redirect_uri=http://127.0.0.1:25566/callback&show_dialog=true&scope=user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing";
-            window.location.href = url; }
+            let id = document.getElementById("clientid").value;
+            let secret = document.getElementById("clientsecret").value;
+            fetch(`http://127.0.0.1:25566/config?id=${id}&secret=${secret}`).then(() => {
+                document.location = "https://accounts.spotify.com/authorize?response_type=code&client_id=" + id + "&redirect_uri=http://127.0.0.1:25566/callback&show_dialog=true&scope=user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing";
+            });
+        }
     </script>
 </head>
 

--- a/src/client/resources/guide/ko_kr.html
+++ b/src/client/resources/guide/ko_kr.html
@@ -46,16 +46,12 @@
     </style>
     <script>
         function redirect() {
-            var xmlHttp1 = new XMLHttpRequest();
-            xmlHttp1.open("GET", "http://127.0.0.1:25566/secret?code=" + document.getElementById('clientsecret').value, true);
-            xmlHttp1.send(null);
-
-            var xmlHttp2 = new XMLHttpRequest();
-            xmlHttp2.open("GET", "http://127.0.0.1:25566/id?code=" + document.getElementById('clientid').value, true);
-            xmlHttp2.send(null);
-
-            url = "https://accounts.spotify.com/authorize?response_type=code&client_id=" + document.getElementById('clientid').value + "&redirect_uri=http://127.0.0.1:25566/callback&show_dialog=true&scope=user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing";
-            window.location.href = url; }
+            let id = document.getElementById("clientid").value;
+            let secret = document.getElementById("clientsecret").value;
+            fetch(`http://127.0.0.1:25566/config?id=${id}&secret=${secret}`).then(() => {
+                document.location = "https://accounts.spotify.com/authorize?response_type=code&client_id=" + id + "&redirect_uri=http://127.0.0.1:25566/callback&show_dialog=true&scope=user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing";
+            });
+        }
     </script>
 </head>
 


### PR DESCRIPTION
Combined /id and /secret to /config with 2 queries. Used .then() on the front page before redirection. Fixes issues from #10.