### PR TITLE
add. CustomCottonScreen and close screen handling

### DIFF
--- a/src/client/java/com/tiji/media/CustomCottonScreen.java
+++ b/src/client/java/com/tiji/media/CustomCottonScreen.java
@@ -1,0 +1,28 @@
+package com.tiji.media;
+
+import io.github.cottonmc.cotton.gui.GuiDescription;
+import io.github.cottonmc.cotton.gui.client.CottonClientScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.input.KeyInput;
+import static com.tiji.media.MediaClient.SETUP_KEY;
+
+public class CustomCottonScreen extends CottonClientScreen {
+
+    public CustomCottonScreen(GuiDescription description) {
+        super(description);
+    }
+
+    /**
+     * Handles closing the screen when the setup key is pressed.
+     * @param input The key input pressed.
+     * @return true if the key press was handled, parent method result otherwise.
+     */
+    @Override
+    public boolean keyPressed(KeyInput input) {
+        if (SETUP_KEY.matchesKey(input)) {
+            MinecraftClient.getInstance().setScreen(null);
+            return true;
+        }
+        return super.keyPressed(input);
+    }
+}

--- a/src/client/java/com/tiji/media/MediaClient.java
+++ b/src/client/java/com/tiji/media/MediaClient.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class MediaClient implements ClientModInitializer {
 	public static final MediaConfig CONFIG = new MediaConfig();
-	private static final KeyBinding SETUP_KEY = new KeyBinding("key.media.general", GLFW.GLFW_KEY_Z, KeyBinding.Category.MISC);
+	public static final KeyBinding SETUP_KEY = new KeyBinding("key.media.general", GLFW.GLFW_KEY_Z, KeyBinding.Category.MISC);
 	public static int tickCount = 0;
 	public static NowPlayingScreen nowPlayingScreen = null;
 
@@ -36,12 +36,12 @@ public class MediaClient implements ClientModInitializer {
 		ClientTickEvents.END_CLIENT_TICK.register((client) -> {
 			while (SETUP_KEY.wasPressed()) {
 				if (isNotSetup()) {
-					client.setScreen(new CottonClientScreen(new SetupScreen()));
+					client.setScreen(new CustomCottonScreen(new SetupScreen()));
 				}else{
 					nowPlayingScreen = new NowPlayingScreen();
 					nowPlayingScreen.updateCoverImage();
 					nowPlayingScreen.updateNowPlaying();
-					client.setScreen(new CottonClientScreen(nowPlayingScreen));
+					client.setScreen(new CustomCottonScreen(nowPlayingScreen));
 				}
 			}
 			if (!isNotSetup() && tickCount % 10 == 0){


### PR DESCRIPTION
### Changes

- Added CustomCottonScreen child class for CottonClientScreen that overrides the keyPressed event in order to, not only open the Now Playing Screen or Setup Screen when the SETUP_KEY is pressed, but also close it when the same key is pressed and the screen is visible.
- Made the SETUP_KEY variable in MediaClient public so that it can be accessed from CustomCottonScreen.
- Use of CustomCottonScreen instead of CottonClientScreen as parameter when calling client.setScreen method in MediaClient.

### Technical Details
I found opening the screen using the Z key but having to close it with the Escape key a little inconvenient. I found that overriding the keyPressed event at the CottonClientScreen class might be the best way to capture the key input event when the Now Playing Screen or Setup Screen are open.

Also, in order to reuse the SETUP_KEY variable in the MediaClient class I had to make it public instead of private.
 
I have close to no experience coding Minecraft mods so there might be a better way to achieve this behaviour or the naming might not be the best. Thank you for your hard work and take your time reviewing these changes!!

### Testing

- [x] Tested default key binding (Z)
- [x] Tested binding to another key
